### PR TITLE
remove build dependency on Test::Exception - rt#99871

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -45,7 +45,6 @@ my %configure_requires = (
 my %build_requires = ();
 my %test_requires = (
 		'Test::More'      => '1.00',
-		'Test::Exception' => '0.32',
 
 		# standard modules:
 		'File::Temp' => 0,

--- a/t/01-test.t
+++ b/t/01-test.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 
 use Test::More tests => 14;
-use Test::Exception;
 use File::Temp qw(tempdir);
 use Expect;
 use Config;
@@ -441,7 +440,8 @@ subtest respawn => sub {
 
 	my $exp = Expect->new;
 	$exp->spawn( $Perl . q{ -e 'print "42\n"'} );
-	throws_ok { $exp->spawn( $Perl . q{ -e 'print "23\n"'} ) } qr/^Cannot reuse an object with an already spawned command/;
+	eval { $exp->spawn( $Perl . q{ -e 'print "23\n"'} ) };
+    like $@, qr/^Cannot reuse an object with an already spawned command/;
 };
 
 

--- a/t/10-internal.t
+++ b/t/10-internal.t
@@ -2,12 +2,12 @@ use strict;
 use warnings;
 
 use Test::More tests => 17;
-use Test::Exception;
 
 use Expect;
 
 my $e = Expect->new;
-throws_ok { $e->_trim_length } qr/^No string passed/;
+eval { $e->_trim_length };
+like $@, qr/^No string passed/;
 is $e->_trim_length('a' x 999), 'a' x 999;
 is $e->_trim_length('a' x 1021), 'a' x 1021;
 is $e->_trim_length('a' x 1023), '...' . 'a' x 1021;
@@ -16,7 +16,8 @@ is $e->_trim_length('a' x 1025), '...' . 'a' x 1021;
 is $e->_trim_length('a' x 1025, 2000), 'a' x 1025;
 is $e->_trim_length('a' x 2001, 2000), 'a' x 2000;
 
-throws_ok { Expect::_trim_length() } qr/^No string passed/;
+eval { Expect::_trim_length() };
+like $@, qr/^No string passed/;
 is Expect::_trim_length(undef, "z" x 1020), 'z' x 1020;
 is Expect::_trim_length(undef, "z" x 1021), 'z' x 1021;
 is Expect::_trim_length(undef, "z" x 1022), '...' . 'z' x 1021;


### PR DESCRIPTION
throws_ok only used 3 times and a simple eval+like covers these tests