### PR TITLE
Correction to explanation link

### DIFF
--- a/lib/Expect.pm
+++ b/lib/Expect.pm
@@ -1953,7 +1953,7 @@ There are several configurable package variables that affect the behavior of Exp
 
 =head1 DESCRIPTION
 
-See an explanation of L<What is Expect|http://code-maven.com/expect>
+See an explanation of L<What is Expect|https://code-maven.com/expect>
 
 The Expect module is a successor of Comm.pl and a descendent of Chat.pl. It
 more closely resembles the Tcl Expect language than its predecessors. It


### PR DESCRIPTION
The link protocol to the explanation of Expect is now https at line 1956