### PR TITLE
recognize 'undef' as a valid timeout

### DIFF
--- a/lib/Expect.pm
+++ b/lib/Expect.pm
@@ -479,11 +479,11 @@ sub expect {
 	croak "expect(): not enough arguments, should be expect(timeout, [patterns...])"
 		if @_ < 1;
 	my $timeout;
-	if ( ! looks_like_number($_[0]) && $self->timeout ) {
-		$timeout = $self->timeout; 
+	if ( looks_like_number($_[0]) or not defined $_[0] ) {
+		$timeout = shift;
 		}
 	else {
-		$timeout = shift;
+		$timeout = $self->timeout; 
 		}
 	my $timeout_hook = undef;
 

--- a/t/timeout.t
+++ b/t/timeout.t
@@ -1,0 +1,48 @@
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use Expect;
+
+my $Perl = $^X;
+my $slow_program = "$Perl t/utils/slow-interaction.pl";
+
+subtest "implicit timeout" => sub {
+	plan tests => 1;
+
+	my $exp = Expect->spawn($slow_program);
+    $exp->timeout(10);
+	$exp->log_user(0);
+
+	$exp->expect( 
+        [ "string to transform", sub { $_[0]->send("banana\n") } ]
+    );
+
+	is $exp->expect( "BANANA" ) => 1;
+};
+
+subtest "undef as timeout" => sub {
+	plan tests => 2;
+
+    subtest "no explicit timeout, we get default" => sub {
+        my $exp = Expect->spawn($slow_program);
+        $exp->timeout(1);
+        $exp->log_user(0);
+
+        # no explicit timeout, we get the default of '1' and fail
+        is $exp->expect( 
+            [ "string to transform", sub { $_[0]->send("banana\n") } ]
+        ) => undef;
+    };
+
+    subtest "explicit timeout, we wait forever" => sub {
+        my $exp = Expect->spawn($slow_program);
+        $exp->timeout(1);
+        $exp->log_user(0);
+
+        is $exp->expect( undef,
+            [ "string to transform", sub { $_[0]->send("banana\n") } ]
+        ) => 1;
+    };
+
+};

--- a/t/utils/slow-interaction.pl
+++ b/t/utils/slow-interaction.pl
@@ -1,0 +1,7 @@
+##!/usr/bin/perl
+
+print "loading...\n";
+sleep 3;
+print "string to transform: ";
+my $data = <>;
+print "transformed: ", uc( $data ), "\n";


### PR DESCRIPTION
`undef` is used to mean 'wait forever'.