### PR TITLE
reverted matching behaviour to v1.25

### DIFF
--- a/lib/Expect.pm
+++ b/lib/Expect.pm
@@ -776,11 +776,11 @@ sub _multi_expect {
 					} elsif ( $pattern->[1] eq '-re' ) {
 
 						if ($Expect::Multiline_Matching) {
-							@matchlist =
-								( ${*$exp}{exp_Accum}  =~ m/($pattern->[2])/m);
+							@matchlist = (${*$exp}{exp_Accum} =~ m/$pattern->[2]()/);
+							($match, $before, $after) = ($&, $`, $');
 						} else {
-							@matchlist =
-								( ${*$exp}{exp_Accum} =~ m/($pattern->[2])/);
+							@matchlist = (${*$exp}{exp_Accum} =~ m/$pattern->[2]()/);
+							($match, $before, $after) = ($&, $`, $');
 						}
 						if (@matchlist) {
 


### PR DESCRIPTION
- fixes before/after matches described in https://github.com/jacoby/expect.pm/issues/10
- copied from https://github.com/eramon-gmbh/expect.pm/commit/341af2fb909a2c7a9d88fccc5b738a28b34590d2#diff-52c6a0c783a1246f8fb3ddcd84bca560186507ec26d60bd48e6a974a6ea91c2e